### PR TITLE
Repeat question if user has wrong pass count

### DIFF
--- a/scripts/npc/9020001.js
+++ b/scripts/npc/9020001.js
@@ -170,7 +170,8 @@ function action(mode, type, selection) {
                                                         eim.gridInsert(cm.getPlayer(), 0);
                                                 }
                                                 else {
-                                                        cm.sendNext("I'm sorry, but that is not the right answer! Please have the correct number of coupons in your inventory.");
+                                                        var question = stage1Questions[eim.gridCheck(cm.getPlayer()) - 1];
+                                                        cm.sendNext("I'm sorry, but that is not the right answer!\r\n" + question);
                                                 }
                                         }
                                 }


### PR DESCRIPTION
Kerning City PQ Stage 1 NPC Cloto
- Originally in HeavenMS, she would tell the user they had the wrong number of passes, but not repeat the question.
- This was mainly a problem for those who accidentally skipped the window and would have to check
- With this fix, cloto follows up her 'wrong answer' speech, but also repeats the proper question associated with each player